### PR TITLE
style: fix biome formatting in state-machine spec

### DIFF
--- a/skills/model-based-testing/state-machine.spec.ts
+++ b/skills/model-based-testing/state-machine.spec.ts
@@ -398,9 +398,6 @@ describe("integration: workflow state machine", () => {
 
   // Defect: invalid workflow jumps must fail loudly in assertion helpers to prevent silent invalid state transitions.
   it("throws on impossible workflow jump", () => {
-    assert.throws(
-      () => assertTransition(workflow, "draft", "published"),
-      /Invalid transition: draft -> published/,
-    );
+    assert.throws(() => assertTransition(workflow, "draft", "published"), /Invalid transition: draft -> published/);
   });
 });


### PR DESCRIPTION
## Summary
- Fix biome formatter violation in `state-machine.spec.ts` — collapse multiline `assert.throws` to single line per biome's 120-char line width

Closes #11

## Test plan
- [x] `npx biome check .` passes with zero errors
- [x] All 309 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)